### PR TITLE
Change the docs folder to be of orginal name

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ This requires that you have the semantic-UI-docs folder adjacent to the folder o
 ```
   dev_folder/
       semantic-ui-sass/
-      docs/
+      Semantic-UI-Docs/
       ...
 ```
 First run the command `npm install`

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,22 +10,22 @@ gulp.task('sass', function () {
     .pipe(sass())
     .pipe(replace('image-url', 'url'))
     .pipe(replace('font-url', 'url'))
-    .pipe(gulp.dest('../docs/out/dist/'));
+    .pipe(gulp.dest('../Semantic-UI-Docs/out/dist/'));
 });
 
 gulp.task('fonts', function() {
   gulp.src('./app/assets/fonts/semantic-ui/**/*.*')
-  .pipe(gulp.dest('../docs/out/dist/semantic-ui'))
+  .pipe(gulp.dest('../Semantic-UI-Docs/out/dist/semantic-ui'))
 });
 
 gulp.task('images', function() {
   gulp.src('./app/assets/images/semantic-ui/*.png')
-  .pipe(gulp.dest('../docs/out/dist/semantic-ui/'))
+  .pipe(gulp.dest('../Semantic-UI-Docs/out/dist/semantic-ui/'))
 });
 
 gulp.task('js', function() {
   gulp.src('./app/assets/javascripts/semantic-ui/*.js')
-  .pipe(gulp.dest('../docs/out/dist/components/'))
+  .pipe(gulp.dest('../Semantic-UI-Docs/out/dist/components/'))
 });
 
 gulp.task('min-js', function() {
@@ -36,7 +36,7 @@ gulp.task('min-js', function() {
           min:'.min.js'
       }
   }))
-  .pipe(gulp.dest('../docs/out/dist/components/'))
+  .pipe(gulp.dest('../Semantic-UI-Docs/out/dist/components/'))
 });
 
 gulp.task('build-docs', ['sass', 'fonts', 'images', 'js', 'min-js']);


### PR DESCRIPTION
Instead of having to rename the docs folder when pulled from Github, this will use the original repo name, Semantic-UI-Docs in the gulp tasks.