### PR TITLE
Correct border radius for “rounded/avatar”-images

### DIFF
--- a/app/assets/stylesheets/semantic-ui/elements/_image.scss
+++ b/app/assets/stylesheets/semantic-ui/elements/_image.scss
@@ -100,7 +100,7 @@ img.ui.image {
 .ui.rounded.image,
 .ui.rounded.images .image > *,
 .ui.rounded.image > * {
-  border-radius: 0.3125em;
+  border-radius: 35%;
 }
 
 /*--------------
@@ -160,7 +160,7 @@ img.ui.bordered.image {
   display: inline-block;
   width: 2em;
   height: 2em;
-  border-radius: 500rem;
+  border-radius: 35%;
 }
 
 /*-------------------


### PR DESCRIPTION
Border-radius for avatars and images with the class .rounded is now set to 35% in order to scale proportionally as small or large size.

**Small**
<img width="66" alt="image___semantic_ui" src="https://cloud.githubusercontent.com/assets/1861703/20003446/cb996434-a286-11e6-95d8-9b46d64eb8db.png">

**Large**
<img width="536" alt="image___semantic_ui" src="https://cloud.githubusercontent.com/assets/1861703/20003431/bf706de2-a286-11e6-9acd-dbe7d56b4d66.png">
