### PR TITLE
[ISSUE-2231] Manually check for name key to return search result

### DIFF
--- a/app/assets/javascripts/semantic-ui.js
+++ b/app/assets/javascripts/semantic-ui.js
@@ -12509,6 +12509,20 @@ $.fn.search = function(parameters) {
                 result  = $result.data(metadata.result) || module.get.result(value, results),
                 returnedValue
               ;
+              // Duct Tape fix for search issue in the Advertiser app, based on Algolia results
+              if (!result) {
+                for (let i = 0; i < results.length; i++) {
+                  if (!results[i] || !results[i].results) {
+                    continue;
+                  }
+                  for (let j = 0; j < results[i].results.length; j++) {
+                    const element = results[i].results[j];
+                    if (element.name === value) {
+                      result = element
+                    }
+                  }
+                }
+              }
               if( $.isFunction(settings.onSelect) ) {
                 if(settings.onSelect.call(element, result, results) === false) {
                   module.debug('Custom onSelect callback cancelled default select action');

--- a/app/assets/javascripts/semantic-ui.js
+++ b/app/assets/javascripts/semantic-ui.js
@@ -12511,14 +12511,14 @@ $.fn.search = function(parameters) {
               ;
               // Duct Tape fix for search issue in the Advertiser app, based on Algolia results
               if (!result) {
-                for (let i = 0; i < results.length; i++) {
+                for (var i = 0; i < results.length; i++) {
                   if (!results[i] || !results[i].results) {
                     continue;
                   }
-                  for (let j = 0; j < results[i].results.length; j++) {
-                    const element = results[i].results[j];
+                  for (var j = 0; j < results[i].results.length; j++) {
+                    var element = results[i].results[j];
                     if (element.name === value) {
-                      result = element
+                      result = element;
                     }
                   }
                 }


### PR DESCRIPTION
This fixes a bug where we cannot search campaigns in the advertiser app because this is broken somehow. I can't make much sense of this code but this duct tape fix solves the error we are having in our app. It is very specific for how our search objects look.